### PR TITLE
fix API URL 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python library for the Withings API
 
 Withings Body metrics Services API
-<http://www.withings.com/en/api/wbsapiv2>
+<http://oauth.withings.com/api/doc>
 
 Uses Oauth 1.0 to authentify. You need to obtain a consumer key
 and consumer secret from Withings by creating an application


### PR DESCRIPTION
The old URL was returning a 404. This URL seems like a good replacement to me.
