### PR TITLE
get the library working on py3k (#4)

### DIFF
--- a/bin/withings
+++ b/bin/withings
@@ -2,8 +2,12 @@
 from withings import *
 from optparse import OptionParser
 import sys
-import ConfigParser
 import os
+
+try:
+    import configparser
+except ImportError:  # Python 2.x fallback
+    import ConfigParser as configparser
 
 
 parser = OptionParser()
@@ -17,12 +21,12 @@ parser.add_option('-c', '--config', dest='config', help="Config file")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
-    print "Missing command!"
+    print("Missing command!")
     sys.exit(1)
 command = args.pop(0)
 
 if not options.config is None and os.path.exists(options.config):
-    config = ConfigParser.ConfigParser(vars(options))
+    config = configparser.ConfigParser(vars(options))
     config.read(options.config)
     options.consumer_key = config.get('withings', 'consumer_key')
     options.consumer_secret = config.get('withings', 'consumer_secret')
@@ -31,34 +35,34 @@ if not options.config is None and os.path.exists(options.config):
     options.user_id = config.get('withings', 'user_id')
 
 if options.consumer_key is None or options.consumer_secret is None:
-    print "You must provide a consumer key and consumer secret"
-    print "Create an Oauth application here: https://oauth.withings.com/partner/add"
+    print("You must provide a consumer key and consumer secret")
+    print("Create an Oauth application here: https://oauth.withings.com/partner/add")
     sys.exit(1)
 
 if options.access_token is None or options.access_token_secret is None or options.user_id is None:
-    print "Missing authentification information!"
-    print "Starting authentification process..."
+    print("Missing authentification information!")
+    print("Starting authentification process...")
     auth = WithingsAuth(options.consumer_key, options.consumer_secret)
     authorize_url = auth.get_authorize_url()
-    print "Go to %s allow the app and copy your oauth_verifier" % authorize_url
+    print("Go to %s allow the app and copy your oauth_verifier") % authorize_url
     oauth_verifier = raw_input('Please enter your oauth_verifier: ')
     creds = auth.get_credentials(oauth_verifier)
     options.access_token = creds.access_token
     options.access_token_secret = creds.access_token_secret
     options.user_id = creds.user_id
-    print ""
+    print("")
 else:
-    creds = WithingsCredentials(options.access_token, options.access_token_secret, 
-                                    options.consumer_key, options.consumer_secret, 
+    creds = WithingsCredentials(options.access_token, options.access_token_secret,
+                                    options.consumer_key, options.consumer_secret,
                                     options.user_id)
 
 client = WithingsApi(creds)
 
 if command == 'saveconfig':
     if options.config is None:
-        print "Missing config filename"
+        print("Missing config filename")
         sys.exit(1)
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.add_section('withings')
     config.set('withings', 'consumer_key', options.consumer_key)
     config.set('withings', 'consumer_secret', options.consumer_secret)
@@ -67,12 +71,12 @@ if command == 'saveconfig':
     config.set('withings', 'user_id', options.user_id)
     with open(options.config, 'wb') as f:
         config.write(f)
-    print "Config file saved to %s" % options.config
+    print("Config file saved to %s" % options.config)
     sys.exit(0)
 
 
 if command == 'userinfo':
-    print client.get_user()
+    print(client.get_user())
     sys.exit(0)
 
 
@@ -81,22 +85,22 @@ if command == 'last':
     if len(args) == 1:
         for n, t in WithingsMeasureGroup.MEASURE_TYPES:
             if n == args[0]:
-                print m.get_measure(t)
+                print(m.get_measure(t))
     else:
         for n, t in WithingsMeasureGroup.MEASURE_TYPES:
-            print "%s: %s" % (n.replace('_', ' ').capitalize(), m.get_measure(t))
+            print("%s: %s" % (n.replace('_', ' ').capitalize(), m.get_measure(t)))
     sys.exit(0)
 
 
 if command == 'subscribe':
     client.subscribe(args[0], args[1])
-    print "Subscribed %s" % args[0]
+    print("Subscribed %s" % args[0])
     sys.exit(0)
 
 
 if command == 'unsubscribe':
     client.unsubscribe(args[0])
-    print "Unsubscribed %s" % args[0]
+    print("Unsubscribed %s" % args[0])
     sys.exit(0)
 
 
@@ -104,12 +108,12 @@ if command == 'list_subscriptions':
     l = client.list_subscriptions()
     if len(l) > 0:
         for s in l:
-            print " - %s " % s['comment']
+            print(" - %s " % s['comment'])
     else:
-        print "No subscriptions"
+        print("No subscriptions")
     sys.exit(0)
 
 
-print "Unknown command"
-print "Available commands: saveconfig, userinfo, last, subscribe, unsubscribe, list_subscriptions"
+print("Unknown command")
+print("Available commands: saveconfig, userinfo, last, subscribe, unsubscribe, list_subscriptions")
 sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==1.2.3
+requests==2.3.0
 requests-oauth==0.4.1
 requests-oauthlib==0.3.2

--- a/withings/__init__.py
+++ b/withings/__init__.py
@@ -25,14 +25,16 @@ print "Your last measured weight: %skg" % measures[0].weight
 
 """
 
+from __future__ import unicode_literals
+
 __title__ = 'withings'
 __version__ = '0.1'
 __author__ = 'Maxime Bouroumeau-Fuseau'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2012 Maxime Bouroumeau-Fuseau'
 
-__all__ = ['WithingsCredentials', 'WithingsAuth', 'WithingsApi',
-           'WithingsMeasures', 'WithingsMeasureGroup']
+__all__ = [str('WithingsCredentials'), str('WithingsAuth'), str('WithingsApi'),
+           str('WithingsMeasures'), str('WithingsMeasureGroup')]
 
 import requests
 from requests_oauthlib import OAuth1, OAuth1Session
@@ -88,10 +90,10 @@ class WithingsApi(object):
 
     def __init__(self, credentials):
         self.credentials = credentials
-        self.oauth = OAuth1(unicode(credentials.consumer_key),
-                            unicode(credentials.consumer_secret),
-                            unicode(credentials.access_token),
-                            unicode(credentials.access_token_secret),
+        self.oauth = OAuth1(credentials.consumer_key,
+                            credentials.consumer_secret,
+                            credentials.access_token,
+                            credentials.access_token_secret,
                             signature_type='query')
         self.client = requests.Session()
         self.client.auth = self.oauth
@@ -102,7 +104,7 @@ class WithingsApi(object):
             params = {}
         params['action'] = action
         r = self.client.request(method, '%s/%s' % (self.URL, service), params=params)
-        response = json.loads(r.content)
+        response = json.loads(r.content.decode())
         if response['status'] != 0:
             raise Exception("Error code %s" % response['status'])
         return response.get('body', None)


### PR DESCRIPTION
Here is my proposed fix for #4: Python 3.x support. Mostly just print statement upgrades, the requests library needed an upgrade, and I used the `unicode_literals` future import for Python 2.x to treat literals as unicode by default. That screwed up the `__all__` import in 2.x, which I worked around by wrapping the names in `str()`