### PR TITLE
Withings Error messages

### DIFF
--- a/withings/__init__.py
+++ b/withings/__init__.py
@@ -127,7 +127,7 @@ class WithingsApi(object):
         r = self.client.request(method, '%s/%s' % (self.URL, service), params=params)
         response = json.loads(r.content.decode())
         if response['status'] != 0:
-            raise Exception("Error code %s" % response['status'])
+            raise Exception("%s (status code %s)" % (STATUS_CODES[response['status']], response['status']))
         return response.get('body', None)
 
     def get_user(self):

--- a/withings/__init__.py
+++ b/withings/__init__.py
@@ -41,6 +41,25 @@ from requests_oauthlib import OAuth1, OAuth1Session
 import json
 import datetime
 
+STATUS_CODES = {
+    # Response status codes as defined in documentation
+    # http://oauth.withings.com/api/doc
+    0: u"Operation was successful",
+    247: u"The userid provided is absent, or incorrect",
+    250: u"The provided userid and/or Oauth credentials do not match",
+    286: u"No such subscription was found",
+    293: u"The callback URL is either absent or incorrect",
+    294: u"No such subscription could be deleted",
+    304: u"The comment is either absent or incorrect",
+    305: u"Too many notifications are already set",
+    342: u"The signature (using Oauth) is invalid",
+    343: u"Wrong Notification Callback Url don't exist",
+    601: u"Too Many Request",
+    2554: u"Wrong action or wrong webservice",
+    2555: u"An unknown error occurred",
+    2556: u"Service is not defined",
+}
+
 
 class WithingsCredentials(object):
     def __init__(self, access_token=None, access_token_secret=None,


### PR DESCRIPTION
Adds proper messages to errors and creates Exception class for Withings exceptions.

Error message definitions will help developers easily understand the error cause without having to refer to the documentation.
`WithingsError` exception class will make it easy to exceptions raised by withings API without having to catch all `Exceptions`. It will also make it possible to handle errors based on the status which is now a field in the `WithigsError` class.

Error messages have been copied verbatim from Withings API documentation at http://oauth.withings.com/api/doc